### PR TITLE
Potential fix for code scanning alert no. 1239: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,5 +1,9 @@
 name: Restyled
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/docker-web-service/security/code-scanning/1239](https://github.com/LanikSJ/docker-web-service/security/code-scanning/1239)

To fix the problem, add an explicit `permissions` block to the workflow file. This can be done at the top level (applies to all jobs) or per job (for finer control). The minimal permissions required for this workflow are likely `contents: read` (to check out code) and `pull-requests: write` (to create, update, and close pull requests). Add the following block near the top of the file, after the `name` and before `on`, or just after `on` for clarity:

```yaml
permissions:
  contents: read
  pull-requests: write
```

This ensures the `GITHUB_TOKEN` used by all jobs in this workflow has only the permissions needed, reducing the risk of privilege escalation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
