### PR TITLE
Potential fix for code scanning alert no. 1236: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -1,5 +1,8 @@
 name: ShiftLeft Scan
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/docker-web-service/security/code-scanning/1236](https://github.com/LanikSJ/docker-web-service/security/code-scanning/1236)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, the `contents: read` permission is sufficient for the `Scan-Build` job, as it primarily reads repository contents and uploads reports.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or specifically to the `Scan-Build` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
