### PR TITLE
Potential fix for code scanning alert no. 1237: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -1,5 +1,9 @@
 name: Update License
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   schedule:
     - cron: '0 10 1 1 *' # 10:00 AM on January 1


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/docker-web-service/security/code-scanning/1237](https://github.com/LanikSJ/docker-web-service/security/code-scanning/1237)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for creating and merging pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `action-update-license-year` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
